### PR TITLE
feat: Allow for statically validating BSN's

### DIFF
--- a/src/Bsn.ts
+++ b/src/Bsn.ts
@@ -1,27 +1,32 @@
 export class Bsn {
-  public bsn;
-  /**
-   * Utility class for using dutch BSN's
-   *
-   * Providing an invalid BSN to the class constructor
-   * will throw an error.
-   *
-   * @param {string} bsn
-   */
-  constructor(bsn: string) {
-    this.bsn = bsn;
-    this.validate();
-  }
 
   /**
    * Check if the provided value can be considered a (formally) valid BSN. No checks
    * are done to check if the BSN is actually in use.
    * This is described in https://www.rvig.nl/bsn/documenten/publicaties/2022/01/02/logisch-ontwerp-bsn-1.6
    */
-  validate() {
-    if (!Number.isInteger(parseInt(this.bsn))) { throw Error('provided BSN is not a number'); }
-    if (this.bsn.length < 8 || this.bsn.length > 9) { throw Error(`provided BSN is of incorrect length, provided length is ${this.bsn.length}`); }
-    if (!this.elfproef()) { throw Error('provided BSN does not satisfy elfproef'); }
+  static validate(bsn: string): { success: boolean; message?: string } {
+    if (!Number.isInteger(parseInt(bsn))) {
+      return {
+        success: false,
+        message: 'provided BSN is not a number',
+      };
+    }
+    if (bsn.length < 8 || bsn.length > 9) {
+      return {
+        success: false,
+        message: `provided BSN is of incorrect length, provided length is ${bsn.length}`,
+      };
+    }
+    if (!Bsn.elfproef(bsn)) {
+      return {
+        success: false,
+        message: 'provided BSN does not satisfy elfproef',
+      };
+    }
+    return {
+      success: true,
+    };
   }
 
   /**
@@ -30,8 +35,8 @@ export class Bsn {
    * @param {string} bsn
    * @returns boolean true if value succeeds the elfproef
    */
-  elfproef() {
-    const digits = this.bsn.split('');
+  static elfproef(bsn: string) {
+    const digits = bsn.split('');
 
     //Old BSN's can be 8 digits long
     if (digits.length == 8) { digits.unshift('0'); }
@@ -45,5 +50,36 @@ export class Bsn {
       }
     });
     return (total % 11 == 0);
+  }
+
+  public bsn: string;
+  /**
+   * Utility class for using dutch BSN's
+   *
+   * Providing an invalid BSN to the class constructor
+   * will throw an error.
+   *
+   * @param {string} bsn
+   */
+  constructor(bsn: string) {
+    this.bsn = bsn;
+    this.validate();
+  }
+
+  /** Validates the BSN. Called by the constructor.
+   * @deprecated for direct use, call the static validate method `Bsn.validate(bsn: string)`, which
+   * provides an error message and status, instead of throwing.
+   */
+  validate() {
+    const result = Bsn.validate(this.bsn);
+    if (result.success) {
+      return;
+    } else {
+      throw Error(result.message);
+    }
+  }
+
+  elfproef() {
+    Bsn.elfproef(this.bsn);
   }
 }

--- a/test/bsn.test.ts
+++ b/test/bsn.test.ts
@@ -1,21 +1,43 @@
 import { Bsn } from '../src/Bsn';
 
-test('bsns valid', async () => {
-  expect(() => new Bsn('999996708')).not.toThrow();
-  expect(() => new Bsn('999996630')).not.toThrow();
-  expect(() => new Bsn('999996642')).not.toThrow();
-  expect(() => new Bsn('999996654')).not.toThrow();
-  expect(() => new Bsn('999996666')).not.toThrow();
-  expect(() => new Bsn('999996678')).not.toThrow();
+describe('Creating a BSN', () => {
+  test('bsns valid', async () => {
+    expect(() => new Bsn('999996708')).not.toThrow();
+    expect(() => new Bsn('999996630')).not.toThrow();
+    expect(() => new Bsn('999996642')).not.toThrow();
+    expect(() => new Bsn('999996654')).not.toThrow();
+    expect(() => new Bsn('999996666')).not.toThrow();
+    expect(() => new Bsn('999996678')).not.toThrow();
+  });
+
+  test('bsns invalid', async () => {
+    // Not numeric
+    expect(() => new Bsn('ditisgeenbsn')).toThrow();
+    // Does not conform to elfproef
+    expect(() => new Bsn('999998620')).toThrow();
+    // Too short
+    expect(() => new Bsn('123456')).toThrow();
+    // Too long
+    expect(() => new Bsn('1234567890')).toThrow();
+  });
 });
 
-test('bsns invalid', async () => {
-  // Not numeric
-  expect(() => new Bsn('ditisgeenbsn')).toThrow();
-  // Does not conform to elfproef
-  expect(() => new Bsn('999998620')).toThrow();
-  // Too short
-  expect(() => new Bsn('123456')).toThrow();
-  // Too long
-  expect(() => new Bsn('1234567890')).toThrow();
+describe('Validating a BSN', () => {
+  test('Elfproef succeeds for valid BSN', async() => {
+    expect(Bsn.elfproef('999996708')).toBeTruthy();
+    expect(Bsn.elfproef('999996630')).toBeTruthy();
+  });
+  test('Elfproef fails for invalid BSN', async() => {
+    expect(Bsn.elfproef('999998620')).toBeFalsy();
+  });
+
+  test('Validation fails for invalid BSN', async() => {
+    expect(Bsn.validate('ditisgeenbsn').success).toBeFalsy();
+    // Does not conform to elfproef
+    expect(Bsn.validate('999998620').success).toBeFalsy();
+    // Too short
+    expect(Bsn.validate('123456').success).toBeFalsy();
+    // Too long
+    expect(Bsn.validate('1234567890').success).toBeFalsy();
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1685,9 +1685,9 @@
     undici-types "~5.26.4"
 
 "@types/node@^18":
-  version "18.19.29"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.29.tgz#e7e9d796c1e195be7e7daf82b4abc50d017fb9db"
-  integrity sha512-5pAX7ggTmWZdhUrhRWLPf+5oM7F80bcKVCBbr0zwEkTNzTJL2CWQjznpFgHYy6GrzkYi2Yjy7DHKoynFxqPV8g==
+  version "18.19.33"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.33.tgz#98cd286a1b8a5e11aa06623210240bcc28e95c48"
+  integrity sha512-NR9+KrpSajr2qBVp/Yt5TU/rp+b5Mayi3+OlMlcg2cVCfRmcG5PWZ7S4+MG9PZ5gWBoc9Pd0BKSRViuBCRPu0A==
   dependencies:
     undici-types "~5.26.4"
 


### PR DESCRIPTION
Allow for validating before constructing a BSN object, to allow more userfriendly flows. Backwards compatible with the previous release.