### PR TITLE
feat: Add environment variable util

### DIFF
--- a/src/environmentVariables.ts
+++ b/src/environmentVariables.ts
@@ -4,12 +4,12 @@
  * Optionally, some values can be provided a default value. Usage:
  * If you need 'process.env.SOME_CONFIG_PARAM` to be set:
  *
- * ```const env = enviromnentVariables['SOME_CONFIG_PARAM']```
+ * ```const env = environmentVariables['SOME_CONFIG_PARAM']```
  *
  * Then use `env.SOME_CONFIG_PARAM`. Will throw if process.env.SOME_CONFIG_PARAM
  * is not set. If you want to set a default value, use as follows:
  *
- * ```const env = enviromnentVariables['SOME_CONFIG_PARAM, SOME_OPTIONAL_PARAM', { 'SOME_OPTIONAL_VALUE': 'someDefault' }]```
+ * ```const env = environmentVariables['SOME_CONFIG_PARAM, SOME_OPTIONAL_PARAM', { 'SOME_OPTIONAL_VALUE': 'someDefault' }]```
  *
  * @param keys the environment keys that need to be set
  * @param defaults default values can be provided for optional keys

--- a/src/environmentVariables.ts
+++ b/src/environmentVariables.ts
@@ -1,0 +1,40 @@
+/**
+ * Check if all required environment variables are set
+ *
+ * Optionally, some values can be provided a default value. Usage:
+ * If you need 'process.env.SOME_CONFIG_PARAM` to be set:
+ *
+ * ```const env = enviromnentVariables['SOME_CONFIG_PARAM']```
+ *
+ * Then use `env.SOME_CONFIG_PARAM`. Will throw if process.env.SOME_CONFIG_PARAM
+ * is not set. If you want to set a default value, use as follows:
+ *
+ * ```const env = enviromnentVariables['SOME_CONFIG_PARAM, SOME_OPTIONAL_PARAM', { 'SOME_OPTIONAL_VALUE': 'someDefault' }]```
+ *
+ * @param keys the environment keys that need to be set
+ * @param defaults default values can be provided for optional keys
+ * @returns
+ */
+export function environmentVariables<T extends readonly string[]>(
+  keys: T,
+  defaults: Partial<Record<T[number], string>> = {}): {
+    [K in T[number]]: string;
+  } {
+  const env = {} as {
+    [K in T[number]]: string;
+  };
+
+  keys.forEach((key) => {
+    // Type assertion to ensure TypeScript understands key is a valid key for defaults
+    const typedKey = key as T[number];
+    const value = process.env[typedKey] ?? defaults[typedKey] ?? '';
+
+    if (!value) {
+      throw new Error(`Environment variable ${typedKey} is missing`);
+    }
+
+    env[typedKey] = value;
+  });
+
+  return env;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export { Bsn } from './Bsn';
 export { AWS } from './AWS';
 export { Storage, S3Storage } from './Storage';
+export { environmentVariables } from './environmentVariables';

--- a/test/environmentVariables.test.ts
+++ b/test/environmentVariables.test.ts
@@ -1,0 +1,46 @@
+import { environmentVariables } from '../src/environmentVariables';
+
+describe('getEnvVariables', () => {
+  beforeEach(() => {
+    // Clear environment variables before each test
+    delete process.env.NODE_ENV;
+    delete process.env.PORT;
+    delete process.env.DB_HOST;
+    delete process.env.DB_PORT;
+    delete process.env.DB_USER;
+    delete process.env.DB_PASSWORD;
+  });
+
+  test('retrieves environment variables successfully', () => {
+    process.env.NODE_ENV = 'development';
+    process.env.PORT = '3000';
+
+    const env = environmentVariables(['NODE_ENV', 'PORT']);
+
+    expect(env.NODE_ENV).toBe('development');
+    expect(env.PORT).toBe('3000');
+  });
+
+  test('throws error if required environment variables are missing', () => {
+    expect(() => {
+      environmentVariables(['NODE_ENV', 'PORT']);
+    }).toThrow('Environment variable NODE_ENV is missing');
+  });
+
+  test('uses default values when environment variables are not set', () => {
+    const env = environmentVariables(['DB_PORT'], {
+      DB_PORT: '5432', // Default value
+    });
+
+    expect(env.DB_PORT).toBe('5432');
+  });
+
+  test('Do not use default values when environment variables are set', () => {
+    process.env.DB_PORT = '3000';
+    const env = environmentVariables(['DB_PORT'], {
+      DB_PORT: '5432', // Default value
+    });
+
+    expect(env.DB_PORT).toBe('3000');
+  });
+});


### PR DESCRIPTION
Adds a utility function that takes an array of
process.env. keys, which throws if any of the values is missing. Optionally, for some keys defaults can be provided.